### PR TITLE
I don't think the changes I made previously made it through the merge

### DIFF
--- a/UserGroups.md
+++ b/UserGroups.md
@@ -6,10 +6,10 @@
 |Cincinnati PowerShell User Group|Jay Ryan / Chris Brucker|Mason, OH|http://cincypowershell.org|[@CincyPowerShell](https://twitter.com/cincypowershell)|[info@cincypowershell.org](mailto:info@cincypowershell.org)
 |Romania PowerShell User Group|Sorin Pasa|Bucharest,Romania|https://www.meetup.com/Romanian-PowerShell-User-Group/|@ROMANIAPUG|romaniapug@yahoo.com|
 |Atlanta PowerShell User Group|Mark Schill/Stephen Owen|Atlanta, Georgia|http://www.meetup.com/Atlanta-PowerShell-Users-Group/ |@ATLPUG|ATLPUG@Foxdeploy.com|
-|Twin Cities|Tim Curwick|"Minneapolis, Minnesota, USA"|http://www.meetup.com/Twin-Cities-PowerShell-User-Group/|||
+|Twin Cities|Tim Curwick|Minneapolis, Minnesota, USA|http://www.meetup.com/Twin-Cities-PowerShell-User-Group/|||
 |Mississippi|Mike F Robbins|Virtual , Online|http://mspsug.com/|@MSPSUG|mspsug@gmail.com|
-|Philadelphia|John Mello/Lido Paglia|"Philadelphia, Pennysylvania, USA"|http://phillyposh.org/|https://twitter.com/phillyposh|info@phillyposh.org|
-|DFW|Josh Miller/Larry Weiss|"Dallas-Fort Worth, Texas, USA"|http://sp.ntpcug.org/PowerShell/default.aspx||DallasFtWorth@powershellgroup.org|
-|Louisville|Joshua Taylor|"Louisville, Kentucky, USA"||@louposh|contact@louposh.org|
+|Philadelphia|John Mello/Lido Paglia|Philadelphia, Pennysylvania, USA|http://phillyposh.org/|https://twitter.com/phillyposh|info@phillyposh.org|
+|DFW|Josh Miller/Larry Weiss|Dallas-Fort Worth, Texas, USA|http://sp.ntpcug.org/PowerShell/default.aspx||DallasFtWorth@powershellgroup.org|
+|Louisville|Joshua Taylor|Louisville, Kentucky, USA||@louposh|contact@louposh.org|
 |Virtual|Joel Bennett|Virtual (Online - No Physical Location)|https://slack.poshcode.org||Jaykul@HuddledMasses.org|
-|Romania|Sorin Pasa|"Bucharest, Romania"|https://www.meetup.com/Romanian-PowerShell-User-Group/|@ROMANIAPUG|romaniapug@yahoo.com|
+|Romania|Sorin Pasa|Bucharest, Romania|https://www.meetup.com/Romanian-PowerShell-User-Group/|@ROMANIAPUG|romaniapug@yahoo.com|

--- a/UserGroups.md
+++ b/UserGroups.md
@@ -1,26 +1,26 @@
 |Group Name|Owner|Location|WebsiteURL|Twitter|Email|
 |----------|-----|--------|----------|-------|-----|
-|Metro Detroit PowerShell User Group|Will Anderson|Southfield, Michigan, USA|https://www.meetup.com/Metro-Detroit-PowerShell-Users-Group/ | N/A | N/A |
-|Arizona PowerShell User Group|Thom Schumacher|Phoenix, Arizona, USA| https://azpowershell.wordpress.com/ | @Azpowershell, #azpowershell | Azpug@outlook.com |
+|Metro Detroit PowerShell User Group|Will Anderson|Southfield, MI, USA|https://www.meetup.com/Metro-Detroit-PowerShell-Users-Group/ | N/A | N/A |
+|Arizona PowerShell User Group|Thom Schumacher|Phoenix, AZ, USA| https://azpowershell.wordpress.com/ | @Azpowershell, #azpowershell | Azpug@outlook.com |
 |Boston|Steve Parankewich/Warren Frame|Boston, MA, USA|http://www.meetup.com/Boston-PowerShell-User-Group/|@BosPSUG| N/A |
 |MTUG Script Club|Jan Egil Ring/Øyvind Kallstad|Oslo, Norway| http://script-club.mtug.no | N/A | N/A |
 |Cincinnati PowerShell User Group|Jay Ryan / Chris Brucker|Mason, OH|http://cincypowershell.org|[@CincyPowerShell](https://twitter.com/cincypowershell)|[info@cincypowershell.org](mailto:info@cincypowershell.org)
 |Romania PowerShell User Group|Sorin Pasa|Bucharest,Romania|https://www.meetup.com/Romanian-PowerShell-User-Group/|@ROMANIAPUG|romaniapug@yahoo.com|
-|Atlanta PowerShell User Group|Mark Schill/Stephen Owen|Atlanta, Georgia|http://www.meetup.com/Atlanta-PowerShell-Users-Group/ |@ATLPUG|ATLPUG@Foxdeploy.com|
-|Twin Cities|Tim Curwick|Minneapolis, Minnesota, USA|http://www.meetup.com/Twin-Cities-PowerShell-User-Group/|||
+|Atlanta PowerShell User Group|Mark Schill/Stephen Owen|Atlanta, GA, USA|http://www.meetup.com/Atlanta-PowerShell-Users-Group/ |@ATLPUG|ATLPUG@Foxdeploy.com|
+|Twin Cities|Tim Curwick|Minneapolis, MN, USA|http://www.meetup.com/Twin-Cities-PowerShell-User-Group/|||
 |Mississippi|Mike F Robbins|Virtual , Online|http://mspsug.com/|@MSPSUG|mspsug@gmail.com|
-|Philadelphia|John Mello/Lido Paglia|Philadelphia, Pennysylvania, USA|http://phillyposh.org/|https://twitter.com/phillyposh|info@phillyposh.org|
-|DFW|Josh Miller/Larry Weiss|Dallas-Fort Worth, Texas, USA|http://sp.ntpcug.org/PowerShell/default.aspx||DallasFtWorth@powershellgroup.org|
-|Louisville|Joshua Taylor|Louisville, Kentucky, USA||@louposh|contact@louposh.org|
+|Philadelphia|John Mello/Lido Paglia|Philadelphia, PA, USA|http://phillyposh.org/|https://twitter.com/phillyposh|info@phillyposh.org|
+|DFW|Josh Miller/Larry Weiss|Dallas-Fort Worth, TX, USA|http://sp.ntpcug.org/PowerShell/default.aspx||DallasFtWorth@powershellgroup.org|
+|Louisville|Joshua Taylor|Louisville, KY, USA||@louposh|contact@louposh.org|
 |Virtual|Joel Bennett|Virtual (Online - No Physical Location)|https://slack.poshcode.org||Jaykul@HuddledMasses.org|
 |Romania|Sorin Pasa|Bucharest, Romania|https://www.meetup.com/Romanian-PowerShell-User-Group/|@ROMANIAPUG|romaniapug@yahoo.com|
-|PowerShell_ES Spanish User Group|Tomas Cribb|"Rosario, Argentina"|https://http://blog.powershell-es.com/|@PowerShell_ES|tomascribb@gmail.com|
-|St. Louis|Michael Lombardi|"St. Louis, Missouri, USA"|https://www.meetup.com/stlpsug|stl.psug@outlook.com|
+|PowerShell_ES Spanish User Group|Tomas Cribb|Rosario, Argentina|https://http://blog.powershell-es.com/|@PowerShell_ES|tomascribb@gmail.com|
+|St. Louis|Michael Lombardi|St. Louis, MO, USA|https://www.meetup.com/stlpsug|stl.psug@outlook.com|
 |Kansas City PowerShell User Group|Robin Haberstroh|Lenexa, KS, USA|http://kcpsug.com|@KCPSUG|kcpsug@outlook.com|
 |Dutch PowerShell User Group|Richard Diphoorn/Jeff Wouters/Jaap Brasser|Netherlands|https://www.dupsug.com|@DUPSUG|info@dupsug.com
-|Nashville|Mick Pletcher|"Nashville, Tennessee, USA"|https://www.meetup.com/Nashville-PowerShell-User-Group/|@nashvillePUG||
-|NYC PowerShell User Group|Doug Finke & Sunny Chakraborty|New York, New York|https://www.meetup.com/NycPowershellMeetup/|@dfinke & "Sunny Chakraborty" <sunnyc7@gmail.com>|finked@hotmail.com  sunnyc7@gmail.com|
+|Nashville|Mick Pletcher|Nashville, TN, USA|https://www.meetup.com/Nashville-PowerShell-User-Group/|@nashvillePUG||
+|NYC PowerShell User Group|Doug Finke & Sunny Chakraborty|New York, NY, USA|https://www.meetup.com/NycPowershellMeetup/|@dfinke & "Sunny Chakraborty" <sunnyc7@gmail.com>|finked@hotmail.com  sunnyc7@gmail.com|
 |Omaha PowerShell User Group|Boe Prox / Josh Duffney|Omaha, NE, USA|https://twitter.com/OmahaPSUG|[@OmahaPSUG](https://twitter.com/OmahaPSUG)|[omahapsug@gmail.com](mailto:omahapsug@gmail.com)|
-|GRPosh|[Thomas Malkewitz](https://dotps1.github.io)|Grand Rapids, Michigan, USA|https://grposh.github.io|[@grposh](https://twitter.com/grposh)|[grposh@outlook.com](mailto:grposh@outlook.com)|
-|MidMo|Josh Rickard|"Columbia, Missouri, USA"|https://www.eventbrite.com/e/midmo-powershell-user-group-tickets-22516367060#|@MidMoPowerShell|midmo-powershell@googlegroups.com|
+|GRPosh|[Thomas Malkewitz](https://dotps1.github.io)|Grand Rapids, MI, USA|https://grposh.github.io|[@grposh](https://twitter.com/grposh)|[grposh@outlook.com](mailto:grposh@outlook.com)|
+|MidMo|Josh Rickard|Columbia, MO, USA|https://www.eventbrite.com/e/midmo-powershell-user-group-tickets-22516367060#|@MidMoPowerShell|midmo-powershell@googlegroups.com|
 |Scottish PowerShell User group|Paul Broadwith|Scotland|https://www.meetup.com/Scottish-PowerShell-User-Group/|@ScotPSUG|https://www.meetup.com/Scottish-PowerShell-User-Group/|


### PR DESCRIPTION
I've removed the double quotes from the locations.
I've updated the States to use postal abbreviations
I've added ", USA" where appropriate, but I see that missed Mason, OH's ,USA.